### PR TITLE
Merge `register` and `subscribe`

### DIFF
--- a/lib/kitty_events.rb
+++ b/lib/kitty_events.rb
@@ -27,6 +27,10 @@ module KittyEvents
     mod.const_set 'HandleWorker', Class.new(::KittyEvents::HandleWorker)
   end
 
+  def handle_worker
+    self::HandleWorker
+  end
+
   def register(*event_names)
     event_names.each do |name|
       handlers[name.to_sym] ||= []
@@ -47,7 +51,7 @@ module KittyEvents
   def trigger(event, object)
     handlers_for_event! event
 
-    self::HandleWorker.perform_later(event.to_s, object)
+    handle_worker.perform_later(event.to_s, object)
   end
 
   def handle(event, object)

--- a/lib/kitty_events.rb
+++ b/lib/kitty_events.rb
@@ -4,61 +4,69 @@ require 'active_job'
 
 # Super simple event system on top of ActiveJob
 #
-# Register a new event:
-#   KittyEvents.register(:upvote)
+# # Create event object
+# module ApplicationEvents
+#   extends KittyEvents
 #
-# Subscribe to this event:
-#   KittyEvents.subscribe(:upvote, Class::Of::EventHandler)
+#   # Register a new event:
+#   register :upvote
+#
+#   # Subscribe to this event:
+#   subscribe :upvote, SpamDetector::UpvoteEventHandler
+# end
+#
+# # Trigger event
+# ApplicationEvents.trigger :upvote, vote
 #
 # An event handler is just a ActiveJob worker that implements .perform(object).
 # When an event is triggered, It will fan out to all subscribers via ActiveJob
 module KittyEvents
-  @@handlers = {}
+  def self.extended(mod)
+    mod.class_variable_set :@@handlers, {}
+    mod.mattr_reader :handlers
+    mod.const_set 'HandleWorker', Class.new(::KittyEvents::HandleWorker)
+  end
 
-  mattr_reader :handlers
-
-  class << self
-    def register(*event_names)
-      event_names.each do |name|
-        handlers[name.to_sym] ||= []
-      end
+  def register(*event_names)
+    event_names.each do |name|
+      handlers[name.to_sym] ||= []
     end
+  end
 
-    def registered
-      handlers.keys
+  def registered
+    handlers.keys
+  end
+
+  def subscribe(event, handler)
+    ensure_valid_handler handler
+
+    handlers = handlers_for_event! event
+    handlers << handler
+  end
+
+  def trigger(event, object)
+    handlers_for_event! event
+
+    self::HandleWorker.perform_later(event.to_s, object)
+  end
+
+  def handle(event, object)
+    handlers_for_event(event) { [] }.each do |handler|
+      handler.perform_later(object)
     end
+  end
 
-    def subscribe(event, handler)
-      ensure_valid_handler handler
+  private
 
-      handlers = handlers_for_event! event
-      handlers << handler
-    end
+  def ensure_valid_handler(handler)
+    raise ArgumentError, "#{handler} has to respond to perform_later" unless handler.respond_to? :perform_later
+  end
 
-    def trigger(event, object)
-      handlers_for_event! event
+  def handlers_for_event!(event)
+    handlers_for_event(event) { raise ArgumentError, "#{event} is not registered" }
+  end
 
-      self::HandleWorker.perform_later(event.to_s, object)
-    end
-
-    def handle(event, object)
-      handlers_for_event(event) { [] }.each do |handler|
-        handler.perform_later(object)
-      end
-    end
-
-    private
-
-    def ensure_valid_handler(handler)
-      raise ArgumentError, "#{handler} has to respond to perform_later" unless handler.respond_to? :perform_later
-    end
-
-    def handlers_for_event!(event)
-      handlers_for_event(event) { raise ArgumentError, "#{event} is not registered" }
-    end
-
-    def handlers_for_event(event, &block)
-      handlers.fetch(event.to_sym, &block)
-    end
+  def handlers_for_event(event, &block)
+    handlers.fetch(event.to_sym, &block)
   end
 end

--- a/lib/kitty_events/handle_worker.rb
+++ b/lib/kitty_events/handle_worker.rb
@@ -3,7 +3,7 @@ require 'active_job'
 module KittyEvents
   class HandleWorker < ActiveJob::Base
     def perform(event, object)
-      KittyEvents.handle(event, object)
+      self.class.parent.handle(event, object)
     end
   end
 end

--- a/lib/kitty_events/handle_worker.rb
+++ b/lib/kitty_events/handle_worker.rb
@@ -1,4 +1,5 @@
 require 'active_job'
+require 'active_support/core_ext/module/introspection'
 
 module KittyEvents
   class HandleWorker < ActiveJob::Base

--- a/spec/kitty_events_spec.rb
+++ b/spec/kitty_events_spec.rb
@@ -5,9 +5,13 @@ describe KittyEvents do
     expect(described_class::VERSION).not_to be nil
   end
 
+  def events
+    described_class
+  end
+
   after(:each) do
     # Don't leak settings across tests
-    described_class.class_variable_set :@@handlers, {}
+    events.class_variable_set :@@handlers, {}
   end
 
   let(:some_handler) { class_double(ActiveJob::Base, perform_later: nil) }
@@ -16,98 +20,98 @@ describe KittyEvents do
 
   describe '.register' do
     it 'adds event to list of events' do
-      described_class.register(:vote)
-      expect(described_class.registered).to include(:vote)
+      events.register(:vote)
+      expect(events.registered).to include(:vote)
     end
 
     it 'handles event names passed as a string' do
-      described_class.register('vote')
-      expect(described_class.registered).to include(:vote)
+      events.register('vote')
+      expect(events.registered).to include(:vote)
     end
 
     it 'handles multiple events' do
-      described_class.register(:vote)
-      described_class.register(:post, :subscribe)
+      events.register(:vote)
+      events.register(:post, :subscribe)
 
-      expect(described_class.registered.sort).to eq %i(vote post subscribe).sort
+      expect(events.registered.sort).to eq %i(vote post subscribe).sort
     end
 
     it 'does not add duplicates' do
-      described_class.register(:vote)
-      described_class.register(:vote)
+      events.register(:vote)
+      events.register(:vote)
 
-      expect(described_class.registered).to eq %i(vote)
+      expect(events.registered).to eq %i(vote)
     end
   end
 
   describe '.subscribe' do
     before do
-      described_class.register(:vote)
+      events.register(:vote)
     end
 
     it 'subscribes to an event' do
-      described_class.subscribe(:vote, some_handler)
+      events.subscribe(:vote, some_handler)
 
-      expect(described_class.handlers[:vote]).to eq [some_handler]
+      expect(events.handlers[:vote]).to eq [some_handler]
     end
 
     it 'subscribes to an event (using string)' do
-      described_class.subscribe('vote', some_handler)
+      events.subscribe('vote', some_handler)
 
-      expect(described_class.handlers[:vote]).to eq [some_handler]
+      expect(events.handlers[:vote]).to eq [some_handler]
     end
 
     it 'handles multiple handlers for a single event' do
-      described_class.subscribe(:vote, some_handler)
-      described_class.subscribe(:vote, another_handler)
+      events.subscribe(:vote, some_handler)
+      events.subscribe(:vote, another_handler)
 
-      expect(described_class.handlers[:vote]).to eq [some_handler, another_handler]
+      expect(events.handlers[:vote]).to eq [some_handler, another_handler]
     end
 
     it 'raises an error when subscribing to an unregistered event' do
       expect do
-        described_class.subscribe(:fake_event, some_handler)
+        events.subscribe(:fake_event, some_handler)
       end.to raise_error ArgumentError
     end
 
     it 'raises an error when subscribing to invalid handler' do
       expect do
-        described_class.subscribe(:vote, 'not a handler')
+        events.subscribe(:vote, 'not a handler')
       end.to raise_error ArgumentError
     end
   end
 
   describe '.trigger' do
     before do
-      allow(described_class::HandleWorker).to receive(:perform_later)
+      allow(events::HandleWorker).to receive(:perform_later)
 
-      described_class.register :vote
+      events.register :vote
     end
 
     it 'raises an error if event does not exist' do
       expect do
-        described_class.trigger(:unregistered_event, some_handler)
+        events.trigger(:unregistered_event, some_handler)
       end.to raise_error ArgumentError
     end
 
     it 'handles event names pass as string' do
-      expect { described_class.trigger('vote', some_handler) }.not_to raise_error
+      expect { events.trigger('vote', some_handler) }.not_to raise_error
     end
 
     it 'enqueues a job to handle the event' do
-      described_class.trigger(:vote, some: some_object)
+      events.trigger(:vote, some: some_object)
 
-      expect(described_class::HandleWorker).to have_received(:perform_later).with('vote', some: some_object)
+      expect(events::HandleWorker).to have_received(:perform_later).with('vote', some: some_object)
     end
   end
 
   describe '.handle' do
     it 'fans out event to each subscribed handler' do
-      described_class.register(:vote)
-      described_class.subscribe(:vote, some_handler)
-      described_class.subscribe(:vote, another_handler)
+      events.register(:vote)
+      events.subscribe(:vote, some_handler)
+      events.subscribe(:vote, another_handler)
 
-      described_class.handle(:vote, some_object)
+      events.handle(:vote, some_object)
 
       expect(some_handler).to have_received(:perform_later).with(some_object)
       expect(another_handler).to have_received(:perform_later).with(some_object)

--- a/spec/kitty_events_spec.rb
+++ b/spec/kitty_events_spec.rb
@@ -6,12 +6,9 @@ describe KittyEvents do
   end
 
   def events
-    described_class
-  end
-
-  after(:each) do
-    # Don't leak settings across tests
-    events.class_variable_set :@@handlers, {}
+    @events ||= Module.new do
+      extend KittyEvents
+    end
   end
 
   let(:some_handler) { class_double(ActiveJob::Base, perform_later: nil) }

--- a/spec/kitty_events_spec.rb
+++ b/spec/kitty_events_spec.rb
@@ -11,107 +11,77 @@ describe KittyEvents do
     end
   end
 
-  let(:some_handler) { class_double(ActiveJob::Base, perform_later: nil) }
+  let(:handler) { class_double(ActiveJob::Base, perform_later: nil) }
   let(:another_handler) { class_double(ActiveJob::Base, perform_later: nil) }
-  let(:some_object) { double('Some::Object') }
+  let(:object) { 'object' }
 
-  describe '.register' do
-    it 'adds event to list of events' do
-      events.register(:vote)
-      expect(events.registered).to include(:vote)
+  describe '.event' do
+    it 'subscribes to an event (using symbol for event name)' do
+      events.event(:vote, handler)
+
+      expect(events.handlers[:vote]).to eq [handler]
     end
 
-    it 'handles event names passed as a string' do
-      events.register('vote')
-      expect(events.registered).to include(:vote)
-    end
+    it 'subscribes to an event (using string for event name)' do
+      events.event('vote', handler)
 
-    it 'handles multiple events' do
-      events.register(:vote)
-      events.register(:post, :subscribe)
-
-      expect(events.registered.sort).to eq %i(vote post subscribe).sort
-    end
-
-    it 'does not add duplicates' do
-      events.register(:vote)
-      events.register(:vote)
-
-      expect(events.registered).to eq %i(vote)
-    end
-  end
-
-  describe '.subscribe' do
-    before do
-      events.register(:vote)
-    end
-
-    it 'subscribes to an event' do
-      events.subscribe(:vote, some_handler)
-
-      expect(events.handlers[:vote]).to eq [some_handler]
-    end
-
-    it 'subscribes to an event (using string)' do
-      events.subscribe('vote', some_handler)
-
-      expect(events.handlers[:vote]).to eq [some_handler]
+      expect(events.handlers[:vote]).to eq [handler]
     end
 
     it 'handles multiple handlers for a single event' do
-      events.subscribe(:vote, some_handler)
-      events.subscribe(:vote, another_handler)
+      events.event(:vote, [handler, another_handler])
 
-      expect(events.handlers[:vote]).to eq [some_handler, another_handler]
-    end
-
-    it 'raises an error when subscribing to an unregistered event' do
-      expect do
-        events.subscribe(:fake_event, some_handler)
-      end.to raise_error ArgumentError
+      expect(events.handlers[:vote]).to eq [handler, another_handler]
     end
 
     it 'raises an error when subscribing to invalid handler' do
-      expect do
-        events.subscribe(:vote, 'not a handler')
-      end.to raise_error ArgumentError
+      expect { events.event(:vote, 'not a handler') }.to raise_error ArgumentError
+    end
+
+    it 'raises an error when subscribe to event twice' do
+      events.event(:vote, handler)
+
+      expect { events.event(:vote, handler) }.to raise_error ArgumentError
     end
   end
 
   describe '.trigger' do
     before do
-      allow(events::HandleWorker).to receive(:perform_later)
-
-      events.register :vote
+      allow(events.handle_worker).to receive(:perform_later)
     end
 
-    it 'raises an error if event does not exist' do
-      expect do
-        events.trigger(:unregistered_event, some_handler)
-      end.to raise_error ArgumentError
+    it 'raises an error when event does not exist' do
+      expect { events.trigger(:unregistered_event, handler) }.to raise_error ArgumentError
     end
 
-    it 'handles event names pass as string' do
-      expect { events.trigger('vote', some_handler) }.not_to raise_error
+    it 'enqueues a job to handle the event (using string for event name)' do
+      events.event :vote, handler
+
+      events.trigger('vote', some: object)
+
+      expect(events.handle_worker).to have_received(:perform_later).with('vote', some: object)
     end
 
-    it 'enqueues a job to handle the event' do
-      events.trigger(:vote, some: some_object)
+    it 'enqueues a job to handle the event (using symbol for event name)' do
+      events.event :vote, handler
 
-      expect(events::HandleWorker).to have_received(:perform_later).with('vote', some: some_object)
+      events.trigger(:vote, some: object)
+
+      expect(events.handle_worker).to have_received(:perform_later).with('vote', some: object)
     end
   end
 
   describe '.handle' do
     it 'fans out event to each subscribed handler' do
-      events.register(:vote)
-      events.subscribe(:vote, some_handler)
-      events.subscribe(:vote, another_handler)
+      events.event(:vote, [handler, another_handler])
+      events.handle(:vote, object)
 
-      events.handle(:vote, some_object)
+      expect(handler).to have_received(:perform_later).with(object)
+      expect(another_handler).to have_received(:perform_later).with(object)
+    end
 
-      expect(some_handler).to have_received(:perform_later).with(some_object)
-      expect(another_handler).to have_received(:perform_later).with(some_object)
+    it 'does not raises when event does not exist' do
+      expect { events.handle(:unregistered_event, object) }.not_to raise_error
     end
   end
 
@@ -148,12 +118,14 @@ describe KittyEvents do
       handle_worker.queue_adapter = :inline
       handle_worker.logger = nil
 
-      register :register, :vote
+      event :register, [
+        TestRegisterHandler
+      ]
 
-      subscribe :register, TestRegisterHandler
-
-      subscribe :vote, TestVoteHandler1
-      subscribe :vote, TestVoteHandler2
+      event :vote, [
+        TestVoteHandler1,
+        TestVoteHandler2
+      ]
     end
 
     before do
@@ -161,19 +133,19 @@ describe KittyEvents do
     end
 
     it 'delivers vote events' do
-      TestEvents.trigger :vote, 'post_vote'
+      TestEvents.trigger :vote, object
 
-      expect(Recorder).to have_received(:record).with :vote_handler_1, 'post_vote'
-      expect(Recorder).to have_received(:record).with :vote_handler_2, 'post_vote'
-      expect(Recorder).not_to have_received(:record).with :register_handler, 'post_vote'
+      expect(Recorder).to have_received(:record).with :vote_handler_1, object
+      expect(Recorder).to have_received(:record).with :vote_handler_2, object
+      expect(Recorder).not_to have_received(:record).with :register_handler, object
     end
 
     it 'delivers register events' do
-      TestEvents.trigger :register, 'user'
+      TestEvents.trigger :register, object
 
-      expect(Recorder).not_to have_received(:record).with :vote_handler_1, 'user'
-      expect(Recorder).not_to have_received(:record).with :vote_handler_2, 'user'
-      expect(Recorder).to have_received(:record).with :register_handler, 'user'
+      expect(Recorder).not_to have_received(:record).with :vote_handler_1, object
+      expect(Recorder).not_to have_received(:record).with :vote_handler_2, object
+      expect(Recorder).to have_received(:record).with :register_handler, object
     end
   end
 end

--- a/spec/kitty_events_spec.rb
+++ b/spec/kitty_events_spec.rb
@@ -145,8 +145,8 @@ describe KittyEvents do
     class TestEvents
       extend KittyEvents
 
-      HandleWorker.queue_adapter = :inline
-      HandleWorker.logger = nil
+      handle_worker.queue_adapter = :inline
+      handle_worker.logger = nil
 
       register :register, :vote
 


### PR DESCRIPTION
### Scope

Changes the following:

```ruby
KittyEvents.register :upvote
KittyEvents.subscribe :upvote, SpamDetector::UpvoteEventHandler

KittyEvents.trigger :upvote, vote
```

To:

```ruby
module ApplicationEvents
  extends KittyEvents

  event :register, Welcome::RegisterEventHandler

  event :upvote, [
    SpamDetector::UpvoteEventHandler,
    Achievements::UpvoteEventHandler,
    CacheCleaner::UpvoteEventHandler
  ]
end

ApplicationEvents.trigger :upvote, vote
```

This allows to have multiple event emitters.
_(Now, It would easier to switch from KittyEvents to something more sophisticated when needed)_ 

Due to the internal changes, now `handle_worker` can be configured:

```ruby
module ApplicationEvents
  extends KittyEvents

  handle_worker.queue_as :events
end
```