### PR TITLE
Fix breakage resulting from Rails 6 upgrade

### DIFF
--- a/lib/kitty_events/handle_worker.rb
+++ b/lib/kitty_events/handle_worker.rb
@@ -4,7 +4,11 @@ require 'active_support/core_ext/module/introspection'
 module KittyEvents
   class HandleWorker < ActiveJob::Base
     def perform(event, object)
-      self.class.parent.handle(event, object)
+      if self.class.respond_to?(:module_parent)
+        self.class.module_parent.handle(event, object)
+      else
+        self.class.parent.handle(event, object)
+      end
     end
   end
 end


### PR DESCRIPTION
Use Module.module_parent instead of Module.parent because Rails
deprecated the parent() method in 6 and removed it in 6.1. This is part
of the Rails 6.1.4 upgrade.